### PR TITLE
Changing name of CohortGenerator tab to "Cohorts" per Patrick's request

### DIFF
--- a/R/CreateConfig.R
+++ b/R/CreateConfig.R
@@ -290,7 +290,7 @@ createDefaultCohortGeneratorConfig <- function(
   
   result <- createModuleConfig(
     moduleId = 'cohortGenerator',
-    tabName = "CohortGenerator",
+    tabName = "Cohorts",
     shinyModulePackage = 'OhdsiShinyModules',
     moduleUiFunction = "cohortGeneratorViewer",
     moduleServerFunction = "cohortGeneratorServer",


### PR DESCRIPTION
It has been requested to rename this tab name. We may end up combining with CohortDiagnostics later, but for now we can rename it