### PR TITLE
Creation of docker deployment for ShinyAppBuilder

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 .github
+Docker
 docs
 extras
 _pkgdown.yml

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,0 +1,72 @@
+name: build-and-push-ohdsi-docker-image-to-Docker-Hub
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  DOCKER_IMAGE: ohdsi/shiny-app-builder
+  MAINTAINER: Jamie Gilbert <gilbert@ohdsi.org>
+  AUTHOR: Jamie Gilbert <gilbert@ohdsi.org>
+  APP_NAME: shiny-app-builder
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tag-match: v(.*)
+          tag-match-group: 1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build Docker image and push to Docker Hub
+        id: build_and_push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./Docker
+          file: ./Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            APP_NAME=${{ env.APP_NAME }}
+            GIT_BRANCH=${{ steps.docker_meta.outputs.version }}
+            GIT_COMMIT_ID_ABBREV=${{ steps.build_params.outputs.sha8 }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: |
+            ${{ steps.docker_meta.outputs.labels }}
+            maintainer=${{ env.MAINTAINER }}
+            org.opencontainers.image.authors=${{ env.AUTHOR }}
+            org.opencontainers.image.vendor=OHDSI
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Inspect Docker image
+        run: |
+          docker pull ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+          docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM ohdsi/ohdsi-shiny-modules
+# Set an argument for the app name and port
+ARG APP_NAME
+ARG SHINY_PORT
+
+# Set arguments for the GitHub branch and commit id abbreviation
+ARG GIT_BRANCH=main
+ARG GIT_COMMIT_ID_ABBREV
+ARG OSM_GIT_BRANCH=main
+
+RUN R CMD javareconf
+# Make sure OSM is up to date
+RUN R -e 'remotes::install_github("OHDSI/OhdsiShinyModules", ref=Sys.getenv("OSM_GIT_BRANCH"), update = "always")'
+# Run install on git ref or specified arg branch
+RUN R -e "ref <- Sys.getenv('GIT_COMMIT_ID_ABBREV', unset=Sys.getenv('GIT_BRANCH')); remotes::install_github('OHDSI/ShinyAppBuilder', ref=ref)"
+
+# Set workdir and copy app files
+WORKDIR /srv/shiny-server/${APP_NAME}
+COPY ./app.R ./
+
+EXPOSE 3838
+RUN R -e "shiny::runApp('/srv/shiny-server/${APP_NAME}', host = '0.0.0.0', port = 3838)"

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,34 @@
+# Using Shiny App builder on OHDSI/ShinyProxyDeploy
+
+1. Ensure data is uploaded to the OHDSI postgres server
+
+2. Add the following to the application.yml file:
+
+```yaml
+
+  specs:
+    ... # Keep old configuration intact, only append
+    - id: <id>_MyStudyName
+        display-name: My study name
+        description: Study description
+        container-cmd: ["R", "-e", "shiny::runApp('/srv/shiny-server/ShinyAppBuilder', host = '0.0.0.0', port = 3838)"]
+        container-image: ohdsi/shiny-app-builder:latest
+        container-volumes:
+          - "/home/jenkins/shinyproxy/.Renviron:/root/.Renviron"
+          - "/home/jenkins/minio/data/sp-app-data:/data"
+        container-env:
+          RESULT_DATABASE_SCHEMA: my_study_result_schema
+          # Set to true or false to enable or disable modules
+          SHINY_ABOUT_CFG: True
+          SHINY_DATA_SOURCE_CFG: True
+          SHINY_CG_CFG: True
+          SHINY_CD_CFG: True
+          SHINY_C_CFG: True
+          SHINY_PLP_CFG: True
+          SHINY_CM_CFG: True
+          SHINY_SCCS_CFG: True
+          SHINY_META_CFG: True
+```
+
+3. Create a pull request
+4. Wait for approval. Once merged into main you will find your app at https://results.ohdsi.org

--- a/Docker/app.R
+++ b/Docker/app.R
@@ -1,0 +1,35 @@
+library(OhdsiShinyModules)
+library(ShinyAppBuilder)
+
+config <- initializeModuleConfig()
+# SET ENVIRONMENT VARS TO TRUE TO INCLUDE IN SHINY APP
+envVars <- c(
+  "SHINY_ABOUT_CFG" = list(TRUE, createDefaultAboutConfig()),
+  "SHINY_DATA_SOURCE_CFG" = list(TRUE, createDefaultDatasourcesConfig()),
+  "SHINY_CG_CFG" = list(TRUE, createDefaultCohortGeneratorConfig()),
+  "SHINY_CD_CFG" = list(TRUE, createDefaultCohortDiagnosticsConfig()),
+  "SHINY_C_CFG" = list(TRUE, createDefaultCharacterizationConfig()),
+  "SHINY_PLP_CFG" = list(TRUE, createDefaultPredictionConfig()),
+  "SHINY_CM_CFG" = list(TRUE, createDefaultCohortMethodConfig()),
+  "SHINY_SCCS_CFG" = list(TRUE, createDefaultSccsConfig()),
+  "SHINY_META_CFG" = list(TRUE, createDefaultEvidenceSynthesisConfig())
+)
+
+for (var in names(envVars)) {
+  useCfg <- as.logical(Sys.getenv(var, unset = envVars[[var]][1]))
+  if (isTRUE(useCfg)) {
+    config <- addModuleConfig(config, envVars[[var]][2])
+  }
+}
+
+resultDatabaseSettings <- createDefaultResultDatabaseSettings(schema = Sys.getenv("RESULT_DATABASE_SCHEMA"))
+connectionDetails <- DatabaseConnector::createConnectionDetails(
+  dbms = "postgresql",
+  server = Sys.getenv("shinydbServer"),
+  port = Sys.getenv("shinydbPort", default = 5432),
+  user = Sys.getenv("shinydbUser"),
+  password = Sys.getenv("shinydbPassword")
+)
+createShinyApp(config = config,
+               connectionDetails = connectionDetails,
+               resultDatabaseSettings = resultDatabaseSettings)

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  ShinyAppBuilder:
+    image: ohdsi/shinyappbuilder
+    env_file: .Renviron
+    build:
+      context: .
+      args:
+        APP_NAME: shinyappbuilder
+    ports:
+      - "3838:3838"


### PR DESCRIPTION
When merged to develop will create a new image for every release of the package. Note - this will require OhdsiShinyModules to be released first.

Also includes a convenient way to launch apps on ShinyProxyDeploy with configurable submodules